### PR TITLE
Add Helm chart for Apprise deployment

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: apprise
+description: A Helm chart for Apprise - Push Notification Library
+type: application
+version: 0.1.0
+appVersion: "1.9.3"
+keywords:
+  - notifications
+  - alerts
+home: https://github.com/caronc/apprise
+maintainers:
+  - name: OpenHands
+    email: openhands@all-hands.dev

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,121 @@
+# Apprise Helm Chart
+
+This Helm chart deploys [Apprise](https://github.com/caronc/apprise) on a Kubernetes cluster.
+
+Apprise is a push notification library that allows you to send notifications to almost all of the most popular notification services available today such as: Telegram, Discord, Slack, Amazon SNS, Gotify, etc.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-apprise`:
+
+```bash
+helm install my-apprise /path/to/apprise-chart
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-apprise` deployment:
+
+```bash
+helm delete my-apprise
+```
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `replicaCount`            | Number of replicas to deploy                    | `1`   |
+| `image.repository`        | Apprise image repository                        | `caronc/apprise` |
+| `image.tag`               | Apprise image tag (defaults to Chart appVersion)| `""`  |
+| `image.pullPolicy`        | Apprise image pull policy                       | `IfNotPresent` |
+| `imagePullSecrets`        | Image pull secrets                              | `[]`  |
+| `nameOverride`            | String to partially override apprise.fullname   | `""`  |
+| `fullnameOverride`        | String to fully override apprise.fullname       | `""`  |
+
+### Apprise parameters
+
+| Name                                 | Description                                                | Value |
+| ------------------------------------ | ---------------------------------------------------------- | ----- |
+| `apprise.persistence.enabled`        | Enable persistence using PVC                               | `false` |
+| `apprise.persistence.storageClass`   | PVC Storage Class for Apprise data volume                  | `""` |
+| `apprise.persistence.accessMode`     | PVC Access Mode for Apprise data volume                    | `ReadWriteOnce` |
+| `apprise.persistence.size`           | PVC Storage Request for Apprise data volume                | `1Gi` |
+| `apprise.env`                        | Environment variables to pass to the container              | `[]` |
+| `apprise.configFiles`                | Config files to mount as ConfigMaps                        | `{}` |
+| `apprise.args`                       | Command line arguments to pass to the apprise command      | `[]` |
+
+### Service parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `service.type`            | Kubernetes Service type                         | `ClusterIP` |
+| `service.port`            | Service HTTP port                               | `8000` |
+
+### Ingress parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `ingress.enabled`         | Enable ingress controller resource              | `false` |
+| `ingress.className`       | IngressClass that will be used                  | `""` |
+| `ingress.annotations`     | Additional annotations for the Ingress resource | `{}` |
+| `ingress.hosts`           | List of hosts for the ingress                   | See values.yaml |
+| `ingress.tls`             | TLS configuration for the ingress               | `[]` |
+
+### Other parameters
+
+| Name                                 | Description                                                | Value |
+| ------------------------------------ | ---------------------------------------------------------- | ----- |
+| `serviceAccount.create`              | Specifies whether a ServiceAccount should be created       | `true` |
+| `serviceAccount.annotations`         | Annotations to add to the ServiceAccount                   | `{}` |
+| `serviceAccount.name`                | The name of the ServiceAccount to use                      | `""` |
+| `podAnnotations`                     | Annotations for Apprise pods                               | `{}` |
+| `podSecurityContext`                 | Security context for Apprise pods                          | `{}` |
+| `securityContext`                    | Security context for Apprise container                     | `{}` |
+| `resources`                          | CPU/Memory resource requests/limits                        | `{}` |
+| `nodeSelector`                       | Node labels for pod assignment                             | `{}` |
+| `tolerations`                        | Tolerations for pod assignment                             | `[]` |
+| `affinity`                           | Affinity for pod assignment                                | `{}` |
+| `autoscaling.enabled`                | Enable autoscaling for Apprise deployment                  | `false` |
+| `autoscaling.minReplicas`            | Minimum number of replicas                                 | `1` |
+| `autoscaling.maxReplicas`            | Maximum number of replicas                                 | `100` |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage                  | `80` |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage            | `nil` |
+
+## Configuration
+
+### Using custom configuration
+
+You can specify custom configuration files using the `apprise.configFiles` parameter:
+
+```yaml
+apprise:
+  configFiles:
+    config.yml: |
+      # Your Apprise configuration here
+```
+
+These files will be mounted as a ConfigMap at `/config` in the container.
+
+### Persistence
+
+The chart mounts a Persistent Volume at `/data` if persistence is enabled. To enable persistence:
+
+```yaml
+apprise:
+  persistence:
+    enabled: true
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 1Gi
+```
+
+## Usage
+
+Once the chart is installed, you can use the Apprise service within your cluster to send notifications.

--- a/helm/examples/values-minimal.yaml
+++ b/helm/examples/values-minimal.yaml
@@ -1,0 +1,18 @@
+# Minimal configuration for Apprise
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 8000
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+apprise:
+  args:
+    - "--help"  # Replace with actual arguments needed for your use case

--- a/helm/examples/values-with-persistence.yaml
+++ b/helm/examples/values-with-persistence.yaml
@@ -1,0 +1,47 @@
+# Example values file with persistence enabled
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: apprise.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: apprise-tls
+      hosts:
+        - apprise.example.com
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+apprise:
+  persistence:
+    enabled: true
+    storageClass: "standard"
+    accessMode: ReadWriteOnce
+    size: 5Gi
+  
+  configFiles:
+    config.yml: |
+      # Example Apprise configuration
+      # Define notification services
+      urls:
+        - discord://webhook_id/webhook_token
+        - telegram://bottoken/ChatID
+        - slack://TokenA/TokenB/TokenC
+        - mailto://user:pass@gmail.com

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,0 +1,25 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "apprise.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "apprise.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "apprise.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "apprise.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+
+For more information about Apprise, please visit:
+https://github.com/caronc/apprise

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "apprise.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "apprise.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "apprise.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "apprise.labels" -}}
+helm.sh/chart: {{ include "apprise.chart" . }}
+{{ include "apprise.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "apprise.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "apprise.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "apprise.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "apprise.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,0 +1,10 @@
+{{- if not (empty .Values.apprise.configFiles) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "apprise.fullname" . }}-config
+  labels:
+    {{- include "apprise.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.apprise.configFiles | nindent 2 }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "apprise.fullname" . }}
+  labels:
+    {{- include "apprise.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "apprise.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "apprise.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "apprise.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.apprise.args }}
+          args:
+            {{- toYaml .Values.apprise.args | nindent 12 }}
+          {{- end }}
+          {{- if .Values.apprise.env }}
+          env:
+            {{- toYaml .Values.apprise.env | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.apprise.persistence.enabled (not (empty .Values.apprise.configFiles)) }}
+          volumeMounts:
+            {{- if .Values.apprise.persistence.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
+            {{- if not (empty .Values.apprise.configFiles) }}
+            - name: config
+              mountPath: /config
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.apprise.persistence.enabled (not (empty .Values.apprise.configFiles)) }}
+      volumes:
+        {{- if .Values.apprise.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "apprise.fullname" . }}
+        {{- end }}
+        {{- if not (empty .Values.apprise.configFiles) }}
+        - name: config
+          configMap:
+            name: {{ include "apprise.fullname" . }}-config
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/templates/hpa.yaml
+++ b/helm/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "apprise.fullname" . }}
+  labels:
+    {{- include "apprise.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "apprise.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "apprise.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "apprise.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.apprise.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "apprise.fullname" . }}
+  labels:
+    {{- include "apprise.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.apprise.persistence.accessMode }}
+  {{- if .Values.apprise.persistence.storageClass }}
+  storageClassName: {{ .Values.apprise.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.apprise.persistence.size }}
+{{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "apprise.fullname" . }}
+  labels:
+    {{- include "apprise.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "apprise.selectorLabels" . | nindent 4 }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "apprise.serviceAccountName" . }}
+  labels:
+    {{- include "apprise.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,104 @@
+# Default values for apprise.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: caronc/apprise
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Apprise specific configuration
+apprise:
+  # Configuration for persistent storage
+  persistence:
+    enabled: false
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    
+  # Environment variables to pass to the container
+  env: []
+  # - name: EXAMPLE_VAR
+  #   value: "example-value"
+  
+  # Config files to mount as ConfigMaps
+  configFiles: {}
+  # config.yml: |
+  #   # Your Apprise configuration here
+  
+  # Command line arguments to pass to the apprise command
+  args: []


### PR DESCRIPTION
This PR adds a Helm chart for deploying Apprise on Kubernetes.

## Features

- Complete Helm chart with all necessary Kubernetes resources
- Configurable deployment options via values.yaml
- Support for persistence, ConfigMaps, and environment variables
- Example configurations for different deployment scenarios
- Comprehensive documentation in README.md

The Helm chart allows users to easily deploy Apprise in Kubernetes environments with various configuration options.